### PR TITLE
Fix links to sklearn

### DIFF
--- a/apricot/functions/facilityLocation.py
+++ b/apricot/functions/facilityLocation.py
@@ -116,16 +116,16 @@ class FacilityLocationSelection(BaseGraphSelection):
 		The number of samples to return.
 
 	metric : str, optional
-		The method for converting a data matrix into a square symmetric matrix
+	        The method for converting a data matrix into a square symmetric matrix
 		of pairwise similarities. If a string, can be any of the metrics
-		implemented in sklearn (see https://scikit-learn.org/stable/modules/
-		generated/sklearn.metrics.pairwise_distances.html), including
-		"precomputed" if one has already generated a similarity matrix. Note
-		that sklearn calculates distance matrices whereas apricot operates on
-		similarity matrices, and so a distances.max() - distances transformation
-		is performed on the resulting distances. For backcompatibility,
-		'corr' will be read as 'correlation'. Default is 'euclidean'.
-
+		implemented in sklearn (see
+		https://scikit-learn.org/stable/modules/generated/sklearn.metrics.pairwise_distances.html),
+		including "precomputed" if one has already generated a similarity
+		matrix. Note that sklearn calculates distance matrices whereas apricot
+		operates on similarity matrices, and so a distances.max() - distances
+		transformation is performed on the resulting distances. For
+		backcompatibility, 'corr' will be read as 'correlation'. Default is
+		'euclidean'.
 
 	initial_subset : list, numpy.ndarray or None, optional
 		If provided, this should be a list of indices into the data matrix
@@ -201,6 +201,7 @@ class FacilityLocationSelection(BaseGraphSelection):
 		growing subset. The first number corresponds to the gain of the first
 		added sample, the second corresponds to the gain of the second added
 		sample, and so forth.
+
 	"""
 
 	def __init__(self, n_samples, metric='euclidean', 

--- a/apricot/functions/facilityLocation.py
+++ b/apricot/functions/facilityLocation.py
@@ -201,7 +201,6 @@ class FacilityLocationSelection(BaseGraphSelection):
 		growing subset. The first number corresponds to the gain of the first
 		added sample, the second corresponds to the gain of the second added
 		sample, and so forth.
-
 	"""
 
 	def __init__(self, n_samples, metric='euclidean', 

--- a/apricot/functions/graphCut.py
+++ b/apricot/functions/graphCut.py
@@ -73,15 +73,16 @@ class GraphCutSelection(BaseGraphSelection):
 		The number of samples to return.
 
 	metric : str, optional
-		The method for converting a data matrix into a square symmetric matrix
+	        The method for converting a data matrix into a square symmetric matrix
 		of pairwise similarities. If a string, can be any of the metrics
-		implemented in sklearn (see https://scikit-learn.org/stable/modules/
-		generated/sklearn.metrics.pairwise_distances.html), including
-		"precomputed" if one has already generated a similarity matrix. Note
-		that sklearn calculates distance matrices whereas apricot operates on
-		similarity matrices, and so a distances.max() - distances transformation
-		is performed on the resulting distances. For backcompatibility,
-		'corr' will be read as 'correlation'. Default is 'euclidean'.
+		implemented in sklearn (see
+		https://scikit-learn.org/stable/modules/generated/sklearn.metrics.pairwise_distances.html),
+		including "precomputed" if one has already generated a similarity
+		matrix. Note that sklearn calculates distance matrices whereas apricot
+		operates on similarity matrices, and so a distances.max() - distances
+		transformation is performed on the resulting distances. For
+		backcompatibility, 'corr' will be read as 'correlation'. Default is
+		'euclidean'.
 
 	alpha : float
 		The weight of the first term in the graph-cut objective, which
@@ -168,6 +169,7 @@ class GraphCutSelection(BaseGraphSelection):
 		growing subset. The first number corresponds to the gain of the first
 		added sample, the second corresponds to the gain of the second added
 		sample, and so forth.
+
 	"""
 
 	def __init__(self, n_samples=10, metric='euclidean', alpha=1,

--- a/apricot/functions/graphCut.py
+++ b/apricot/functions/graphCut.py
@@ -169,7 +169,6 @@ class GraphCutSelection(BaseGraphSelection):
 		growing subset. The first number corresponds to the gain of the first
 		added sample, the second corresponds to the gain of the second added
 		sample, and so forth.
-
 	"""
 
 	def __init__(self, n_samples=10, metric='euclidean', alpha=1,

--- a/apricot/functions/saturatedCoverage.py
+++ b/apricot/functions/saturatedCoverage.py
@@ -65,16 +65,16 @@ class SaturatedCoverageSelection(BaseGraphSelection):
 		The number of samples to return.
 
 	metric : str, optional
-	        The method for converting a data matrix into a square symmetric
-		matrix of pairwise similarities. If a string, can be any of the
-		metrics implemented in sklearn (see
+	        The method for converting a data matrix into a square symmetric matrix
+		of pairwise similarities. If a string, can be any of the metrics
+		implemented in sklearn (see
 		https://scikit-learn.org/stable/modules/generated/sklearn.metrics.pairwise_distances.html),
-		including "precomputed" if one has already generated a
-		similarity matrix. Note that sklearn calculates distance
-		matrices whereas apricot operates on similarity matrices, and
-		so a distances.max() - distances transformation is performed on
-		the resulting distances. For backcompatibility, 'corr' will be
-		read as 'correlation'. Default is 'euclidean'.
+		including "precomputed" if one has already generated a similarity
+		matrix. Note that sklearn calculates distance matrices whereas apricot
+		operates on similarity matrices, and so a distances.max() - distances
+		transformation is performed on the resulting distances. For
+		backcompatibility, 'corr' will be read as 'correlation'. Default is
+		'euclidean'.
 
 	alpha : float
 		The threshold at which to saturate. Larger values of alpha are closer
@@ -159,7 +159,6 @@ class SaturatedCoverageSelection(BaseGraphSelection):
 		growing subset. The first number corresponds to the gain of the first
 		added sample, the second corresponds to the gain of the second added
 		sample, and so forth.
-
 	"""
 
 	def __init__(self, n_samples=10, metric='euclidean', alpha=0.1,

--- a/apricot/functions/saturatedCoverage.py
+++ b/apricot/functions/saturatedCoverage.py
@@ -65,15 +65,16 @@ class SaturatedCoverageSelection(BaseGraphSelection):
 		The number of samples to return.
 
 	metric : str, optional
-		The method for converting a data matrix into a square symmetric matrix
-		of pairwise similarities. If a string, can be any of the metrics
-		implemented in sklearn (see https://scikit-learn.org/stable/modules/
-		generated/sklearn.metrics.pairwise_distances.html), including
-		"precomputed" if one has already generated a similarity matrix. Note
-		that sklearn calculates distance matrices whereas apricot operates on
-		similarity matrices, and so a distances.max() - distances transformation
-		is performed on the resulting distances. For backcompatibility,
-		'corr' will be read as 'correlation'. Default is 'euclidean'.
+	        The method for converting a data matrix into a square symmetric
+		matrix of pairwise similarities. If a string, can be any of the
+		metrics implemented in sklearn (see
+		https://scikit-learn.org/stable/modules/generated/sklearn.metrics.pairwise_distances.html),
+		including "precomputed" if one has already generated a
+		similarity matrix. Note that sklearn calculates distance
+		matrices whereas apricot operates on similarity matrices, and
+		so a distances.max() - distances transformation is performed on
+		the resulting distances. For backcompatibility, 'corr' will be
+		read as 'correlation'. Default is 'euclidean'.
 
 	alpha : float
 		The threshold at which to saturate. Larger values of alpha are closer
@@ -158,6 +159,7 @@ class SaturatedCoverageSelection(BaseGraphSelection):
 		growing subset. The first number corresponds to the gain of the first
 		added sample, the second corresponds to the gain of the second added
 		sample, and so forth.
+
 	"""
 
 	def __init__(self, n_samples=10, metric='euclidean', alpha=0.1,

--- a/apricot/functions/sumRedundancy.py
+++ b/apricot/functions/sumRedundancy.py
@@ -134,7 +134,6 @@ class SumRedundancySelection(BaseGraphSelection):
 		growing subset. The first number corresponds to the gain of the first
 		added sample, the second corresponds to the gain of the second added
 		sample, and so forth.
-
 	"""
 
 	def __init__(self, n_samples=10, metric='euclidean', 

--- a/apricot/functions/sumRedundancy.py
+++ b/apricot/functions/sumRedundancy.py
@@ -45,16 +45,16 @@ class SumRedundancySelection(BaseGraphSelection):
 		The number of samples to return.
 
 	metric : str, optional
-		The method for converting a data matrix into a square symmetric matrix
+	        The method for converting a data matrix into a square symmetric matrix
 		of pairwise similarities. If a string, can be any of the metrics
-		implemented in sklearn (see https://scikit-learn.org/stable/modules/
-		generated/sklearn.metrics.pairwise_distances.html), including
-		"precomputed" if one has already generated a similarity matrix. Note
-		that sklearn calculates distance matrices whereas apricot operates on
-		similarity matrices, and so a distances.max() - distances transformation
-		is performed on the resulting distances. For backcompatibility,
-		'corr' will be read as 'correlation'. Default is 'euclidean'.
-
+		implemented in sklearn (see
+		https://scikit-learn.org/stable/modules/generated/sklearn.metrics.pairwise_distances.html),
+		including "precomputed" if one has already generated a similarity
+		matrix. Note that sklearn calculates distance matrices whereas apricot
+		operates on similarity matrices, and so a distances.max() - distances
+		transformation is performed on the resulting distances. For
+		backcompatibility, 'corr' will be read as 'correlation'. Default is
+		'euclidean'.
 
 	initial_subset : list, numpy.ndarray or None, optional
 		If provided, this should be a list of indices into the data matrix
@@ -134,6 +134,7 @@ class SumRedundancySelection(BaseGraphSelection):
 		growing subset. The first number corresponds to the gain of the first
 		added sample, the second corresponds to the gain of the second added
 		sample, and so forth.
+
 	"""
 
 	def __init__(self, n_samples=10, metric='euclidean', 


### PR DESCRIPTION
Some of the hyperlinks are broken by a line break in the online docs. For example from https://apricot-select.readthedocs.io/en/latest/functions/facilityLocation.html:
![image](https://user-images.githubusercontent.com/9124668/129106910-22570690-e385-4e85-b9c4-3f922a3fdfde.png)

This PR should fixes online links, but will make the line containing the URL pretty long in the docstrings.