### PR TITLE
Mark docstring as raw, to preserve math notation

### DIFF
--- a/apricot/functions/sumRedundancy.py
+++ b/apricot/functions/sumRedundancy.py
@@ -8,7 +8,7 @@ from .base import BaseGraphSelection
 from tqdm import tqdm
 
 class SumRedundancySelection(BaseGraphSelection):
-	"""A selector based off a sum redundancy submodular function.
+	r"""A selector based off a sum redundancy submodular function.
 	
 	The sum redundancy function is a graph-based function that penalizes 
 	redundancy among the selected set. This approach is straightforward, 


### PR DESCRIPTION
Fixes the following warning:

```
apricot/functions/sumRedundancy.py:30: SyntaxWarning: "\s" is an invalid escape sequence.
Such sequences will not work in the future. Did you mean "\\s"? A raw string is also an option.
    f(X, V) = \sum_{x, y \in V} \phi(x, y) - \sum_{x, y\in X} \phi(x,y)
```
